### PR TITLE
feat(crypto): add Curve25519MlKem768Ed25519MlDsa65 named key type

### DIFF
--- a/crypto/keytype.go
+++ b/crypto/keytype.go
@@ -63,8 +63,9 @@ var (
 	Ed25519    = KeyType{simple: AlgEd25519}
 
 	// Recommended compound types
-	Curve25519Ed25519               = CompoundKey(AlgCurve25519, AlgNone, AlgEd25519, AlgNone)
-	Curve25519MlKem768Ed25519Falcon = CompoundKey(AlgCurve25519, AlgMlKem768, AlgEd25519, AlgFalcon)
+	Curve25519Ed25519                = CompoundKey(AlgCurve25519, AlgNone, AlgEd25519, AlgNone)
+	Curve25519MlKem768Ed25519Falcon  = CompoundKey(AlgCurve25519, AlgMlKem768, AlgEd25519, AlgFalcon)
+	Curve25519MlKem768Ed25519MlDsa65 = CompoundKey(AlgCurve25519, AlgMlKem768, AlgEd25519, AlgMlDsa65)
 )
 
 // RsaKey returns a KeyType for an RSA keypair with the given bit length.


### PR DESCRIPTION
## Summary

- Adds `Curve25519MlKem768Ed25519MlDsa65` to the named compound key type vars in `crypto/keytype.go`, alongside the existing `Curve25519MlKem768Ed25519Falcon`
- The new constant uses `AlgMlDsa65` (NIST FIPS 204) as the post-quantum signer instead of Falcon
- `AlgMlDsa65` has been available in `virgil-crypto-c/wrappers/go` since v0.19.0-rc.8

## Context

The `VEDML512` JWT signing algorithm added in `virgil-services-core-kit` (PR #168) uses this key type for ML-DSA-65 hybrid tokens. Having a named constant avoids callers spelling out `CompoundKey(AlgCurve25519, AlgMlKem768, AlgEd25519, AlgMlDsa65)` inline.

## Test plan

- `go build ./...` passes
- `go test ./crypto/...` passes (existing key generation and round-trip tests cover compound hybrid key paths)